### PR TITLE
Add authentication and Postgres

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,12 @@
+# Credenciales administrador
+ADMIN_EMAIL=lbadilla1970@gmail.com
+ADMIN_PASSWORD=Laubach.70
+
+# Conexion a base de datos
+DATABASE_URL=postgresql://postgres:postgres@db:5432/appdb
+
+# Configuracion SMTP para recuperar contrasena
+SMTP_SERVER=smtp.example.com
+SMTP_PORT=587
+SMTP_USER=usuario@example.com
+SMTP_PASSWORD=clave

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.pyc
+.env

--- a/app.py
+++ b/app.py
@@ -1,42 +1,180 @@
+import os
 import streamlit as st
 import pandas as pd
-import numpy as np
 from dashboards import general, grupo, mapa
-from utils.calculos import calculo_1
 from utils.charts import kpi_card
+from database import SessionLocal
+from init_db import init_db
+import auth
+from models import User, Role, Company, Data
 
 st.set_page_config(layout="wide")
+init_db()
 
-# Simula o carga los datos
-np.random.seed(42)
-df = pd.DataFrame({
-    'Categoría': np.random.choice(['A', 'B', 'C', 'D'], size=200),
-    'Valor': np.random.randint(10, 100, size=200),
-    'Fecha': pd.date_range(start='2023-01-01', periods=200, freq='D'),
-    'Grupo': np.random.choice(['X', 'Y'], size=200)
-})
+def get_db():
+    return SessionLocal()
 
-# Sidebar para navegación
-pagina = st.sidebar.selectbox("Seleccione una vista", [
-    "Resumen General", 
-    "Análisis por Grupo", 
-    "Mapa"
-])
+def load_data(db, company_id):
+    rows = db.query(Data).filter_by(company_id=company_id).all()
+    return pd.DataFrame([
+        {
+            'Categoría': r.category,
+            'Valor': r.value,
+            'Fecha': r.date,
+            'Grupo': r.group
+        } for r in rows
+    ])
 
+def admin_panel(db):
+    st.header('Panel de Administración')
+    st.subheader('Usuarios')
+    users = db.query(User).all()
+    data = [
+        {
+            'Email': u.email,
+            'Empresa': u.company.name if u.company else '',
+            'Rol': u.role.name if u.role else ''
+        } for u in users
+    ]
+    st.table(pd.DataFrame(data))
+    st.subheader('Crear Usuario')
+    with st.form('crear_usuario'):
+        email = st.text_input('Email')
+        password = st.text_input('Contraseña', type='password')
+        empresa = st.text_input('Empresa')
+        roles = [r.name for r in db.query(Role).all()]
+        rol = st.selectbox('Rol', roles)
+        submit = st.form_submit_button('Crear')
+    if submit:
+        company = db.query(Company).filter_by(name=empresa).first()
+        if not company:
+            company = Company(name=empresa)
+            db.add(company)
+            db.commit()
+            db.refresh(company)
+        role = db.query(Role).filter_by(name=rol).first()
+        auth.create_user(db, email, password, company.id, role.id)
+        st.success('Usuario creado')
 
-# Lógica de navegación
-if pagina == "Resumen General":
-    col1, col2, col3 = st.columns(3)
-    with col1:
-        kpi_card("Dotación", value="250", delta="+10 respecto al mes anterior", color="#1f77b4", width=200, height=100)
-    with col2:
-        kpi_card("Sueldo Promedio", "$1.200.000", "-2%", "#2ca02c", width=200, height=100)
-    with col3:
-        kpi_card("Rotación Mensual", "3.2%", "+0.4%", "#d62728", width=200, height=100)
-        
-    general.mostrar(df)
-elif pagina == "Análisis por Grupo":
-    grupo.mostrar(df)
-elif pagina == "Mapa":
-    mapa.mostrar(df)
+    st.subheader('Roles')
+    roles = db.query(Role).all()
+    st.table(pd.DataFrame([{'id': r.id, 'name': r.name} for r in roles]))
+    new_role = st.text_input('Nuevo Rol')
+    if st.button('Agregar Rol') and new_role:
+        if not db.query(Role).filter_by(name=new_role).first():
+            db.add(Role(name=new_role))
+            db.commit()
+            st.success('Rol agregado')
 
+if 'user_id' not in st.session_state:
+    st.session_state.user_id = None
+if 'page' not in st.session_state:
+    st.session_state.page = 'login'
+
+def login_page(db):
+    st.title('Iniciar Sesión')
+    with st.form('login'):
+        email = st.text_input('Email')
+        password = st.text_input('Contraseña', type='password')
+        submit = st.form_submit_button('Ingresar')
+    if submit:
+        user = auth.authenticate(db, email, password)
+        if user:
+            st.session_state.user_id = user.id
+            st.session_state.page = 'app'
+            st.experimental_rerun()
+        else:
+            st.error('Credenciales inválidas')
+    if st.button('¿Olvidó su contraseña?'):
+        st.session_state.page = 'forgot'
+        st.experimental_rerun()
+
+def forgot_page(db):
+    st.title('Recuperar Contraseña')
+    with st.form('forgot'):
+        email = st.text_input('Email')
+        submit = st.form_submit_button('Enviar')
+    if submit:
+        user = db.query(User).filter_by(email=email).first()
+        if user:
+            token = auth.generate_reset_token(db, user)
+            auth.send_reset_email(email, token)
+        st.success('Si el correo existe se enviará un token.')
+    if st.button('Volver'):
+        st.session_state.page = 'login'
+        st.experimental_rerun()
+
+def reset_page(db):
+    st.title('Restablecer Contraseña')
+    with st.form('reset'):
+        email = st.text_input('Email')
+        token = st.text_input('Token')
+        new_pw = st.text_input('Nueva Contraseña', type='password')
+        submit = st.form_submit_button('Cambiar')
+    if submit:
+        user = auth.verify_reset_token(db, email, token)
+        if user:
+            auth.change_password(db, user, new_pw)
+            st.success('Contraseña actualizada')
+        else:
+            st.error('Token inválido')
+    if st.button('Volver'):
+        st.session_state.page = 'login'
+        st.experimental_rerun()
+
+def main_app(db):
+    user = db.get(User, st.session_state.user_id)
+    if not user:
+        st.session_state.page = 'login'
+        st.experimental_rerun()
+    st.sidebar.write(f'Conectado como: {user.email}')
+    if st.sidebar.button('Cerrar sesión'):
+        st.session_state.user_id = None
+        st.session_state.page = 'login'
+        st.experimental_rerun()
+
+    if user.role and user.role.name == 'Administrador':
+        show_panel = st.sidebar.checkbox('Panel Administrador')
+    else:
+        show_panel = False
+
+    if show_panel:
+        admin_panel(db)
+        return
+
+    pagina = st.sidebar.selectbox('Seleccione una vista', [
+        'Resumen General', 'Análisis por Grupo', 'Mapa'
+    ])
+    df = load_data(db, user.company_id)
+
+    if pagina == 'Resumen General':
+        col1, col2, col3 = st.columns(3)
+        with col1:
+            kpi_card('Dotación', value='250', delta='+10 respecto al mes anterior',
+                     color='#1f77b4', width=200, height=100)
+        with col2:
+            kpi_card('Sueldo Promedio', '$1.200.000', '-2%', '#2ca02c', width=200, height=100)
+        with col3:
+            kpi_card('Rotación Mensual', '3.2%', '+0.4%', '#d62728', width=200, height=100)
+        general.mostrar(df)
+    elif pagina == 'Análisis por Grupo':
+        grupo.mostrar(df)
+    elif pagina == 'Mapa':
+        mapa.mostrar(df)
+
+page_func = {
+    'login': login_page,
+    'forgot': forgot_page,
+    'reset': reset_page,
+    'app': main_app
+}
+
+def run_app():
+    db = get_db()
+    try:
+        page_func[st.session_state.page](db)
+    finally:
+        db.close()
+
+if __name__ == '__main__':
+    run_app()

--- a/auth.py
+++ b/auth.py
@@ -1,0 +1,63 @@
+from passlib.hash import bcrypt
+from sqlalchemy.orm import Session
+from models import User, PasswordReset
+from datetime import datetime, timedelta
+import secrets
+import smtplib
+import os
+from email.message import EmailMessage
+
+RESET_EXPIRY_HOURS = 1
+
+def authenticate(db: Session, email: str, password: str):
+    user = db.query(User).filter_by(email=email).first()
+    if user and bcrypt.verify(password, user.password_hash):
+        return user
+    return None
+
+def create_user(db: Session, email: str, password: str, company_id: int, role_id: int):
+    hashed = bcrypt.hash(password)
+    user = User(email=email, password_hash=hashed,
+                company_id=company_id, role_id=role_id)
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+    return user
+
+def change_password(db: Session, user: User, new_password: str):
+    user.password_hash = bcrypt.hash(new_password)
+    db.commit()
+
+def generate_reset_token(db: Session, user: User):
+    token = secrets.token_urlsafe(16)
+    expiry = datetime.utcnow() + timedelta(hours=RESET_EXPIRY_HOURS)
+    rec = PasswordReset(user_id=user.id, token=token, expiry=expiry)
+    db.add(rec)
+    db.commit()
+    return token
+
+def verify_reset_token(db: Session, email: str, token: str):
+    user = db.query(User).filter_by(email=email).first()
+    if not user:
+        return None
+    rec = db.query(PasswordReset).filter_by(user_id=user.id, token=token).first()
+    if rec and rec.expiry >= datetime.utcnow():
+        return user
+    return None
+
+def send_reset_email(to_email: str, token: str):
+    server = os.getenv('SMTP_SERVER')
+    port = int(os.getenv('SMTP_PORT', '587'))
+    user = os.getenv('SMTP_USER')
+    password = os.getenv('SMTP_PASSWORD')
+    if not all([server, port, user, password]):
+        return
+    msg = EmailMessage()
+    msg['Subject'] = 'Recuperación de contraseña'
+    msg['From'] = user
+    msg['To'] = to_email
+    msg.set_content(f'Su token de recuperación es: {token}')
+    with smtplib.SMTP(server, port) as smtp:
+        smtp.starttls()
+        smtp.login(user, password)
+        smtp.send_message(msg)

--- a/database.py
+++ b/database.py
@@ -1,0 +1,7 @@
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+import os
+
+DATABASE_URL = os.getenv('DATABASE_URL', 'postgresql://postgres:postgres@db:5432/appdb')
+engine = create_engine(DATABASE_URL)
+SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,24 @@ services:
     networks:
       - automatiza-network
     restart: unless-stopped
+    env_file:
+      - .env
+    depends_on:
+      - db
+  db:
+    image: postgres:16
+    environment:
+      POSTGRES_DB: appdb
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    networks:
+      - automatiza-network
 
 networks:
   automatiza-network:
     external: true
+
+volumes:
+  postgres_data:

--- a/init_db.py
+++ b/init_db.py
@@ -1,0 +1,57 @@
+import os
+import numpy as np
+import pandas as pd
+from datetime import datetime
+from sqlalchemy.orm import Session
+from models import Base, Role, Company, User, Data
+from passlib.hash import bcrypt
+from database import engine, SessionLocal
+
+
+def init_db():
+    Base.metadata.create_all(engine)
+    db = SessionLocal()
+    try:
+        # Roles por defecto
+        for rname in ['Usuario', 'Administrador']:
+            if not db.query(Role).filter_by(name=rname).first():
+                db.add(Role(name=rname))
+        db.commit()
+
+        # Empresa Ecoscom
+        ecoscom = db.query(Company).filter_by(name='Ecoscom').first()
+        if not ecoscom:
+            ecoscom = Company(name='Ecoscom')
+            db.add(ecoscom)
+            db.commit()
+            db.refresh(ecoscom)
+
+        # Datos de ejemplo
+        if not db.query(Data).first():
+            np.random.seed(42)
+            df = pd.DataFrame({
+                'category': np.random.choice(['A', 'B', 'C', 'D'], size=200),
+                'value': np.random.randint(10, 100, size=200),
+                'date': pd.date_range(start='2023-01-01', periods=200, freq='D'),
+                'group': np.random.choice(['X', 'Y'], size=200)
+            })
+            for _, row in df.iterrows():
+                db.add(Data(category=row['category'], value=int(row['value']),
+                            date=row['date'].date(), group=row['group'],
+                            company_id=ecoscom.id))
+            db.commit()
+
+        # Usuario administrador por env vars
+        admin_email = os.getenv('ADMIN_EMAIL')
+        admin_password = os.getenv('ADMIN_PASSWORD')
+        if admin_email and admin_password:
+            admin = db.query(User).filter_by(email=admin_email).first()
+            admin_role = db.query(Role).filter_by(name='Administrador').first()
+            if not admin:
+                hashed = bcrypt.hash(admin_password)
+                admin = User(email=admin_email, password_hash=hashed,
+                             company_id=ecoscom.id, role_id=admin_role.id)
+                db.add(admin)
+                db.commit()
+    finally:
+        db.close()

--- a/models.py
+++ b/models.py
@@ -1,0 +1,44 @@
+from sqlalchemy import Column, Integer, String, ForeignKey, Date, Float, DateTime
+from sqlalchemy.orm import declarative_base, relationship
+from datetime import datetime
+
+Base = declarative_base()
+
+class Role(Base):
+    __tablename__ = 'roles'
+    id = Column(Integer, primary_key=True)
+    name = Column(String, unique=True)
+
+class Company(Base):
+    __tablename__ = 'companies'
+    id = Column(Integer, primary_key=True)
+    name = Column(String, unique=True)
+
+class User(Base):
+    __tablename__ = 'users'
+    id = Column(Integer, primary_key=True)
+    email = Column(String, unique=True, nullable=False)
+    password_hash = Column(String, nullable=False)
+    company_id = Column(Integer, ForeignKey('companies.id'))
+    role_id = Column(Integer, ForeignKey('roles.id'))
+
+    company = relationship('Company')
+    role = relationship('Role')
+
+class Data(Base):
+    __tablename__ = 'data'
+    id = Column(Integer, primary_key=True)
+    category = Column(String)
+    value = Column(Integer)
+    date = Column(Date)
+    group = Column(String)
+    company_id = Column(Integer, ForeignKey('companies.id'))
+    company = relationship('Company')
+
+class PasswordReset(Base):
+    __tablename__ = 'password_resets'
+    id = Column(Integer, primary_key=True)
+    user_id = Column(Integer, ForeignKey('users.id'))
+    token = Column(String, unique=True)
+    expiry = Column(DateTime, default=datetime.utcnow)
+    user = relationship('User')

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,7 @@ numpy
 matplotlib
 plotly
 altair
+sqlalchemy
+psycopg2-binary
+passlib
+python-dotenv


### PR DESCRIPTION
## Summary
- integrate SQLAlchemy models for users, roles, companies and data
- initialize database with example data and admin user via env vars
- add authentication utilities with password recovery via email
- rewrite app to require login and support admin panel
- connect to a Postgres database through Docker
- document environment variables

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`
- `pip install -r requirements.txt` *(fails: Cannot connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6877d193150c8327903e1c5468407590