### PR TITLE
Fix licitacion load with numeric excel headers

### DIFF
--- a/utils/licitaciones.py
+++ b/utils/licitaciones.py
@@ -25,8 +25,8 @@ COLUMN_MAP = {
 
 def _read_excel(path='datos/licitaciones.xlsx'):
     df = pd.read_excel(path, header=HEADER_ROW)
-    # Normalize column names by stripping spaces
-    df.columns = [c.strip() if isinstance(c, str) else c for c in df.columns]
+    # Normalize column names and ensure they are strings
+    df.columns = [str(c).strip() for c in df.columns]
     # Some spreadsheets might store the first column with a slightly different
     # name. Fallback to using the first column when the expected label is
     # missing.


### PR DESCRIPTION
## Summary
- ensure excel headers are strings when loading licitaciones

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68787aa34efc8327bdb4aab5250795e9