### PR TITLE
Fix for reading licitaciones Excel

### DIFF
--- a/utils/licitaciones.py
+++ b/utils/licitaciones.py
@@ -37,11 +37,13 @@ def _read_excel(path='datos/licitaciones.xlsx'):
     df = df.rename(columns=COLUMN_MAP)
     if 'Unnamed: 2' in df.columns:
         df = df.rename(columns={'Unnamed: 2': 'col3'})
-    else:
-        df['col3'] = ''
     if 'Unnamed: 7' in df.columns:
         df = df.rename(columns={'Unnamed: 7': 'col8'})
-    else:
+    # Remove any other leftover Excel index columns like 'Unnamed: 1'
+    df = df.loc[:, ~df.columns.str.contains('^Unnamed')]
+    if 'col3' not in df.columns:
+        df['col3'] = ''
+    if 'col8' not in df.columns:
         df['col8'] = ''
     for col in COLUMN_MAP.values():
         if col not in df.columns:


### PR DESCRIPTION
## Summary
- drop unused Excel columns when reading licitaciones spreadsheets

## Testing
- `python3 -m py_compile app.py auth.py database.py init_db.py models.py utils/*.py dashboards/*.py`


------
https://chatgpt.com/codex/tasks/task_e_68787bf33c588327a2f59e4e0dabffed